### PR TITLE
fix: 移除 exe 檔案檢測以避免安全警告 / Remove exe detection to avoid security warn…

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"unsafe"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
-	"golang.org/x/sys/windows"
 )
 
 // App struct
@@ -82,97 +80,16 @@ func (a *App) CreateModZip(mainLanguage string, subLanguage string) (string, err
 	return filepath.Join(outputFolder, "Dual Dialog.zip"), nil
 }
 
-// IsValidKCM2Folder checks if the given path is a valid KCM2 folder
+// IsValidKCM2Folder checks if the given path is a valid KCM2 folder.
+// It only requires a "Localization" subfolder to be present, so users
+// can test with just the language pak files without a full game install.
 func validateKCM2Folder(path string) error {
-	// Normalize the path separator
-	exePath := filepath.Join(path, "Bin", "Win64MasterMasterSteamPGO", "KingdomCome.exe")
-
-	// Check if the file exists
-	_, err := os.Stat(exePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("KingdomCome.exe not found")
-		}
-		return fmt.Errorf("error checking KingdomCome.exe: %w", err)
+	localizationPath := filepath.Join(path, "Localization")
+	info, err := os.Stat(localizationPath)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("Localization folder not found in the selected directory")
 	}
-
-	// Get file description
-	description, err := getFileDescription(exePath)
-	if err != nil {
-		return fmt.Errorf("error getting file description: %w", err)
-	}
-
-	// Check if the description matches
-	if description != "Kingdom Come: Deliverance II" {
-		return fmt.Errorf("invalid file description: %s", description)
-	}
-
 	return nil
 }
 
-// getFileDescription retrieves the description of the given executable file
-func getFileDescription(filePath string) (string, error) {
-	// Get file version info size
-	var handle windows.Handle
-	size, err := windows.GetFileVersionInfoSize(filePath, &handle)
-	if err != nil {
-		return "", fmt.Errorf("unable to get version info size: %w", err)
-	}
 
-	// Allocate buffer to store version info
-	info := make([]byte, size)
-	err = windows.GetFileVersionInfo(filePath, 0, size, unsafe.Pointer(&info[0]))
-	if err != nil {
-		return "", fmt.Errorf("unable to get version info: %w", err)
-	}
-
-	// First, get the language and code page
-	var langPtr unsafe.Pointer
-	var langLen uint32
-	err = windows.VerQueryValue(
-		unsafe.Pointer(&info[0]),
-		`\VarFileInfo\Translation`,
-		unsafe.Pointer(&langPtr),
-		&langLen,
-	)
-	if err != nil {
-		return "", fmt.Errorf("unable to query translation info: %w", err)
-	}
-
-	if langPtr == nil || langLen == 0 {
-		return "", fmt.Errorf("no translation info found")
-	}
-
-	// Extract language and code page
-	type LangCodePage struct {
-		Language uint16
-		CodePage uint16
-	}
-
-	langs := (*[100]LangCodePage)(langPtr)[:langLen/4]
-
-	// Try each available language and code page
-	for _, lang := range langs {
-		// Format the query string with the actual language and code page
-		subBlock := fmt.Sprintf("\\StringFileInfo\\%04x%04x\\FileDescription",
-			lang.Language, lang.CodePage)
-
-		var valuePtr unsafe.Pointer
-		var valueLen uint32
-
-		err = windows.VerQueryValue(
-			unsafe.Pointer(&info[0]),
-			subBlock,
-			unsafe.Pointer(&valuePtr),
-			&valueLen,
-		)
-
-		if err == nil && valuePtr != nil && valueLen > 0 {
-			// Convert UTF-16 pointer to Go string
-			fileDesc := (*[1024]uint16)(valuePtr)[:valueLen:valueLen]
-			return windows.UTF16ToString(fileDesc), nil
-		}
-	}
-
-	return "", fmt.Errorf("file description not found")
-}

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,7 @@ go 1.22.0
 
 toolchain go1.23.5
 
-require (
-	github.com/wailsapp/wails/v2 v2.10.1
-	golang.org/x/sys v0.30.0
-)
+require github.com/wailsapp/wails/v2 v2.10.1
 
 require (
 	github.com/bep/debounce v1.2.1 // indirect
@@ -34,6 +31,7 @@ require (
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )
 


### PR DESCRIPTION
# 移除 exe 檔案檢測以避免安全警告 / Remove exe detection to avoid security warnings

## 問題描述 / Problem Description

原始代碼在驗證遊戲資料夾時會檢測 `KingdomCome.exe` 並讀取其檔案版本資訊，導致 Windows Defender 及其他防毒軟體觸發安全警告並阻止程式執行。

The original code validated the game folder by detecting `KingdomCome.exe` and reading its file version info, which triggered Windows Defender security warnings and prevented users from running the tool.

### 為何觸發安全警告 / Why Security Warnings Occurred

1. **訪問其他程式的 exe 檔案** — 防毒軟體會將此視為可疑行為
2. **使用 Windows API 讀取檔案版本資訊** — `GetFileVersionInfoSize`、`GetFileVersionInfo`、`VerQueryValue` 等 API
3. **未經簽名的程式執行敏感操作** — 組合使用以上行為觸發啟發式檢測

1. **Accessing other programs' exe files** — Antivirus software flags this as suspicious behavior
2. **Using Windows APIs to read file version info** — `GetFileVersionInfoSize`, `GetFileVersionInfo`, `VerQueryValue`, etc.
3. **Unsigned binary performing sensitive operations** — The combination triggers heuristic detection

---

## 修復方案 / Solution

### 新的驗證邏輯

只檢查遊戲目錄下是否存在 `Localization` 資料夾：

```go
func validateKCM2Folder(path string) error {
	localizationPath := filepath.Join(path, "Localization")
	info, err := os.Stat(localizationPath)
	if err != nil || !info.IsDir() {
		return fmt.Errorf("Localization folder not found in the selected directory")
	}
	return nil
}
```

### 優勢 / Benefits

✅ **不觸發安全警告** — 僅使用標準檔案系統 API  
✅ **更輕量** — 移除了 `unsafe` 和 `golang.org/x/sys/windows` 依賴  
✅ **更靈活** — 使用者可以只複製 `Localization` 資料夾進行測試，無需完整遊戲安裝  
✅ **更快速** — 不需要讀取和解析 exe 檔案的版本資訊  

✅ **No security warnings** — Only uses standard filesystem APIs  
✅ **Lighter** — Removed `unsafe` and `golang.org/x/sys/windows` dependencies  
✅ **More flexible** — Users can work with just the `Localization` folder without full game install  
✅ **Faster** — No need to read and parse exe file version info  

---

## 保持兼容性 / Backward Compatibility

✅ **無破壞性變更 / No breaking changes**

- 所有使用完整遊戲安裝路徑的使用者不受影響
- 驗證邏輯依然有效（`Localization` 資料夾是工具運作的必要條件）
- All users with full game installation paths are unaffected
- Validation logic remains effective (`Localization` folder is required for the tool to work)

---

## 測試驗證 / Testing

- ✅ 編譯通過 / Compiles successfully
- ✅ 不再觸發 Windows Defender 警告 / No longer triggers Windows Defender warnings
- ✅ 正確驗證包含 `Localization` 資料夾的路徑 / Correctly validates paths with `Localization` folder
- ✅ 正確拒絕不包含 `Localization` 資料夾的路徑 / Correctly rejects paths without `Localization` folder

---

## 相關檔案 / Files Changed

- `app.go`: 
  - 移除 `unsafe` 和 `golang.org/x/sys/windows` 導入
  - 簡化 `validateKCM2Folder()` 函式
  - 刪除 `getFileDescription()` 函式
- `go.mod`: 
  - 將 `golang.org/x/sys` 從直接依賴改為間接依賴

- `app.go`:
  - Removed `unsafe` and `golang.org/x/sys/windows` imports
  - Simplified `validateKCM2Folder()` function
  - Removed `getFileDescription()` function
- `go.mod`:
  - Changed `golang.org/x/sys` from direct to indirect dependency

---

感謝您開發這個出色的工具！這個修復將讓更多使用者能順利使用本工具。

Thank you for creating this excellent tool! This fix will allow more users to run it smoothly.
